### PR TITLE
adapted schemas for FlatSharp compatibility

### DIFF
--- a/KHUtils.Schemas/datamultimap.fbs
+++ b/KHUtils.Schemas/datamultimap.fbs
@@ -4,7 +4,7 @@ namespace khutils.data_multimap;
 /// simple simili-multimap type for Flatbuffers
 
 /// container for random data
-table Data {
+table MapEntryData {
 	data: [ubyte];
 }
 
@@ -14,7 +14,7 @@ table Data {
 /// values: array of Data
 table MapEntry {
 	id: string(key);
-	values: [Data];
+	values: [MapEntryData];
 }
 
 /// container for multimap entries

--- a/KHUtils.Schemas/stringmap.fbs
+++ b/KHUtils.Schemas/stringmap.fbs
@@ -7,7 +7,7 @@ namespace khutils.hashstring_map;
 /// id: hash
 /// value: string
 table MapEntry {
-	id: ulong(key, hash: "fnv1_64");
+	id: ulong(key); //, hash: "fnv1_64"
 	value: string;
 }
 


### PR DESCRIPTION
- **removed FlatSharp-incompatible attribute 'hash' from khutils.hashstring_map.MapEntry**
- **renamed khutils.data_multimap.Data -> khutils.data_multimap.MapEntryData**
